### PR TITLE
Remove ended container from docker host

### DIFF
--- a/robokops.go
+++ b/robokops.go
@@ -326,7 +326,15 @@ func runContainer(feature string, action string, binds []string) {
 	if err != nil {
 		ppError("Failed to show logs of container: "+containerID, err)
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+		// Remove the ended container if not in dev mode
+		if *dev == false {
+			if err := dockerCli.ContainerRemove(ctx, containerID, types.ContainerRemoveOptions{}); err != nil {
+				ppError(fmt.Sprintf("Failed to remove container: %s", containerID), err)
+			}
+		}
+	}()
 	stdcopy.StdCopy(os.Stdout, os.Stderr, out)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it:**
We need to clean the executed pods to clean the docker host containers list. Useful for when the tools is used against a non-internal docker host, in which we don't want the logs to be retrieved after the job.

Will need a version MAJ !