### PR TITLE
elastic-stack/fluentd: enhance error logs

### DIFF
--- a/bom.yaml
+++ b/bom.yaml
@@ -17,7 +17,7 @@ features:
   version: 0.4.1
 - name: elastic-stack
   image: scalair/robokops-elastic-stack
-  version: 0.5.2
+  version: 0.5.3
 - name: external-dns
   image: scalair/robokops-external-dns
   version: 0.4.1

--- a/k8s/elastic-stack/CHANGELOG.md
+++ b/k8s/elastic-stack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 - 2020-07-08
+### Changed
+- fluentd: enhance error logs when it fails to push logs to elasticsearch
+
 ## 0.5.2 - 2020-06-24
 ### Changed
 - Update fluentd chart to v2.4.2

--- a/k8s/elastic-stack/src/fluentd/values.yaml
+++ b/k8s/elastic-stack/src/fluentd/values.yaml
@@ -128,8 +128,7 @@ configMaps:
       ssl_version "#{ENV['OUTPUT_SSL_VERSION']}"
       logstash_format true
       logstash_prefix fluentd
-      # Set to true to log 400 errors
-      log_es_400_reason false
+      log_es_400_reason true
       <buffer>
         @type file
         path /var/log/fluentd-buffers/kubernetes.system.buffer


### PR DESCRIPTION
It enhance error logs when fluentd fails to push logs into elasticsearch.